### PR TITLE
chore: update git url before cloning enrichment plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ venv
 .coverage
 *.swp
 *.log
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,4 @@ venv
 .coverage
 *.swp
 *.log
-.git
+**/.git

--- a/.github/workflows/pr-onto-dev.yaml
+++ b/.github/workflows/pr-onto-dev.yaml
@@ -25,7 +25,7 @@ jobs:
         export VERSION=${{ steps.branch-name.outputs.current_branch }}
         rm -rf rudder-alerta-enrichment-plugin
         git config --global url."https://${{secrets.PAT}}:x-oauth-basic@github.com/rudderlabs".insteadOf "https://github.com/rudderlabs"
-        git clone -b "$(cat RUDDER_ENRICH_PLUGIN_BRANCH_NAME)" git clone https://github.com/rudderlabs/rudder-alerta-enrichment-plugin.git
+        git clone -b "$(cat RUDDER_ENRICH_PLUGIN_BRANCH_NAME)" https://github.com/rudderlabs/rudder-alerta-enrichment-plugin.git
         docker build --no-cache --build-arg=COMMIT_ID_VALUE="$(git log --format="%H" -n 1)" -t rudderlabs/alerta:$VERSION .
         docker push rudderlabs/alerta:$VERSION
         rm -rf rudder-alerta-enrichment-plugin

--- a/.github/workflows/pr-onto-dev.yaml
+++ b/.github/workflows/pr-onto-dev.yaml
@@ -24,7 +24,8 @@ jobs:
         docker login --username rudderlabs --password '${{ secrets.DOCKER_HUB_PASSWORD }}'
         export VERSION=${{ steps.branch-name.outputs.current_branch }}
         rm -rf rudder-alerta-enrichment-plugin
-        git clone -b "$(cat RUDDER_ENRICH_PLUGIN_BRANCH_NAME)" https://${{ secrets.PAT_USERNAME }}:${{ secrets.PAT }}@github.com/rudderlabs/rudder-alerta-enrichment-plugin.git
+        git config --global url."https://${{secrets.PAT}}:x-oauth-basic@github.com/rudderlabs".insteadOf "https://github.com/rudderlabs"
+        git clone -b "$(cat RUDDER_ENRICH_PLUGIN_BRANCH_NAME)" git clone https://github.com/rudderlabs/rudder-alerta-enrichment-plugin.git
         docker build --no-cache --build-arg=COMMIT_ID_VALUE="$(git log --format="%H" -n 1)" -t rudderlabs/alerta:$VERSION .
         docker push rudderlabs/alerta:$VERSION
         rm -rf rudder-alerta-enrichment-plugin

--- a/.github/workflows/push-onto-master.yaml
+++ b/.github/workflows/push-onto-master.yaml
@@ -29,7 +29,8 @@ jobs:
         docker login --username rudderlabs --password '${{ secrets.DOCKER_HUB_PASSWORD }}'
         export VERSION=${{steps.version_check_staging.outputs.releaseVersion}}
         rm -rf rudder-alerta-enrichment-plugin
-        git clone -b "$(cat RUDDER_ENRICH_PLUGIN_BRANCH_NAME)" https://${{ secrets.PAT_USERNAME }}:${{ secrets.PAT }}@github.com/rudderlabs/rudder-alerta-enrichment-plugin.git
+        git config --global url."https://${{secrets.PAT}}:x-oauth-basic@github.com/rudderlabs".insteadOf "https://github.com/rudderlabs"
+        git clone -b "$(cat RUDDER_ENRICH_PLUGIN_BRANCH_NAME)" https://github.com/rudderlabs/rudder-alerta-enrichment-plugin.git
         docker build --no-cache --build-arg=COMMIT_ID_VALUE="$(git log --format="%H" -n 1)" -t rudderlabs/alerta:$VERSION .
         docker push rudderlabs/alerta:$VERSION
         rm -rf rudder-alerta-enrichment-plugin


### PR DESCRIPTION
Fix github personal access token exposed in the docker image
- Set the github `user` and `pat` in github `url` and then clone the enrichment plugin repo
- Add .`git` folders to `.dockerignore `

